### PR TITLE
Add QA docker build

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,19 @@
+name: QA Docker Image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: praekeltfoundation/molo-basic-who
+          tag_with_ref: true
+          tag_with_sha: true


### PR DESCRIPTION
This adds a github action to build and push a tagged docker image for use in QA on merges to master