### PR TITLE
Fix missing quote in un-used translation files

### DIFF
--- a/locale/ky/LC_MESSAGES/django.po
+++ b/locale/ky/LC_MESSAGES/django.po
@@ -135,8 +135,8 @@ msgid "Change Language"
 msgstr "Тилди өзгөртүү"
 
 #: whomplates/base.html:148
-msgid "who
-msgstr "who
+msgid "who"
+msgstr "who"
 
 #: whomplates/base.html:154
 #: whomplates/profiles/register.html:6

--- a/locale/my/LC_MESSAGES/django.po
+++ b/locale/my/LC_MESSAGES/django.po
@@ -136,8 +136,8 @@ msgid "Change Language"
 msgstr "ဘာသာစကား ေျပာင္းလဲမည္။"
 
 #: whoemplates/base.html:148
-msgid "who
-msgstr "who
+msgid "who"
+msgstr "who"
 
 #: whoemplates/base.html:154
 #: whoemplates/profiles/register.html:6

--- a/locale/ne/LC_MESSAGES/django.po
+++ b/locale/ne/LC_MESSAGES/django.po
@@ -134,8 +134,8 @@ msgid "Change Language"
 msgstr "भाषा परिवर्तन"
 
 #: whotemplates/base.html:148
-msgid "who
-msgstr "who
+msgid "who"
+msgstr "who"
 
 #: whotemplates/base.html:154
 #: whotemplates/profiles/register.html:6

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -136,8 +136,8 @@ msgid "Change Language"
 msgstr "Mudar idioma"
 
 #: whotemplates/base.html:148
-msgid "who
-msgstr "who
+msgid "who"
+msgstr "who"
 
 #: whotemplates/base.html:154
 #: whotemplates/profiles/register.html:6

--- a/locale/pt_MZ/LC_MESSAGES/django.po
+++ b/locale/pt_MZ/LC_MESSAGES/django.po
@@ -135,8 +135,8 @@ msgid "Change Language"
 msgstr "Mudar idioma"
 
 #: whotemplates/base.html:148
-msgid "who
-msgstr "who
+msgid "who"
+msgstr "who"
 
 #: whotemplates/base.html:154
 #: whotemplates/profiles/register.html:6

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -134,8 +134,8 @@ msgid "Change Language"
 msgstr "Badilisha Lugha"
 
 #: whotemplates/base.html:148
-msgid "who
-msgstr "who
+msgid "who"
+msgstr "who"
 
 #: whotemplates/base.html:154
 #: whotemplates/profiles/register.html:6

--- a/locale/th/LC_MESSAGES/django.po
+++ b/locale/th/LC_MESSAGES/django.po
@@ -132,8 +132,8 @@ msgid "Change Language"
 msgstr "เปลี่ยนภาษา"
 
 #: whotemplates/base.html:148
-msgid "who
-msgstr "who
+msgid "who"
+msgstr "who"
 
 #: whotemplates/base.html:154
 #: whotemplates/profiles/register.html:6


### PR DESCRIPTION
Some languages that we aren't currently using have broken translation files. this fixes them